### PR TITLE
Issue 14 rm formatted cells

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -22,8 +22,11 @@ namespace qxlpy
           <tab id='qxltab' label='QXLPY'>
             <group id='qxlpy' label='QXLPY'>
               <button id='expandfunc' label='Expand Function'
-                onAction='OnButtonPressed' size='large'
+                onAction='expandFuncButton' size='large' screentip='Expand Function (Ctrl-INS)'
                 imageMso='ConditionalFormattingColorScalesGallery' />
+              <button id='removefunc' label='Remove Function'
+                onAction='removeFuncButton' size='large' screentip='Remove Function (Ctrl-Shift-DEL)'
+                imageMso='TableDelete' />
             </group >
           </tab>
         </tabs>
@@ -36,9 +39,15 @@ namespace qxlpy
             dynamic xlApp = ExcelDnaUtil.Application;
         }
 
-        public void OnButtonPressed(IRibbonControl control)
+        public void expandFuncButton(IRibbonControl control)
         {
             AutoFill.AutoFuncFormat();
+        }
+
+        public void removeFuncButton(IRibbonControl control)
+        {
+            AutoFill.AutoDataClear();
+            AutoFill.AutoFuncClear();
         }
     }
     // END: public class RibbonController : ExcelRibbon

--- a/main.cs
+++ b/main.cs
@@ -12,10 +12,9 @@ namespace qxlpy
     [ComVisible(true)]
     public class RibbonController : ExcelRibbon
     {
-        public static string? old_formula;
-
         public override string GetCustomUI(string RibbonID)
         {
+            // note: onLoad option can be added after customUI to run a method when the ribbon loads
             return @"
       <customUI xmlns='http://schemas.microsoft.com/office/2009/07/customui'>
       <ribbon>
@@ -33,6 +32,18 @@ namespace qxlpy
         }
 
         public void OnButtonPressed(IRibbonControl control)
+        {
+            AutoFill.AutoFuncFormat();
+        }
+    }
+    // END: public class RibbonController : ExcelRibbon
+
+
+    public static class AutoFill
+    {
+        public static string? old_formula;
+
+        public static void AutoFuncFormat()
         {
             // Check if there is an active worksheet
             dynamic xlApp = ExcelDnaUtil.Application;
@@ -177,7 +188,7 @@ namespace qxlpy
             }
         }
     }
-    // END: public class RibbonController : ExcelRibbon
+    // END: public static clase AutoFill
 
 
     public static class ExManip
@@ -201,7 +212,7 @@ namespace qxlpy
                     ea_range.UnMerge();
                     ea_range.Clear();
                 }
-                bt[0].Value = RibbonController.old_formula;
+                bt[0].Value = AutoFill.old_formula;
                 throw new ApplicationException("Cannot overwrite non-empty cell(s): " + range.Address);
 
             }
@@ -266,6 +277,12 @@ namespace qxlpy
             foreach (object o in obj) {
                 CheckType(o);
             }
+        }
+
+        [ExcelCommand(Name = "MyTestCommand", ShortCut = "^{INSERT}")]
+        public static void testcommand()
+        {
+            AutoFill.AutoFuncFormat();
         }
 
         [ExcelFunction(Name = "QxlpyGetPath")]

--- a/main.cs
+++ b/main.cs
@@ -16,7 +16,7 @@ namespace qxlpy
         public override string GetCustomUI(string RibbonID)
         {
             return @"
-      <customUI xmlns='http://schemas.microsoft.com/office/2009/07/customui' onLoad='DisableAutoCalculate'>
+      <customUI xmlns='http://schemas.microsoft.com/office/2009/07/customui' onLoad='OnLoad'>
       <ribbon>
         <tabs>
           <tab id='qxltab' label='QXLPY'>
@@ -31,7 +31,7 @@ namespace qxlpy
     </customUI>";
         }
 
-        public void DisableAutoCalculate(IRibbonUI ribbon)
+        public void OnLoad(IRibbonUI ribbon)
         {
             dynamic xlApp = ExcelDnaUtil.Application;
         }
@@ -90,11 +90,11 @@ namespace qxlpy
 
             // Get formula name
             old_formula = xlApp.Cells(y, x).Formula;
-            var rgx_f = new Regex(@"[a-zA-Z][a-zA-Z0-9]+");
+            var rgx_f = new Regex(@"[a-zA-Z][a-zA-Z0-9_]+");
             Match match_f = rgx_f.Match(old_formula);
 
             if (!match_f.Success) {
-                ExManip.WriteLog("Formula must start with [a-zA-Z] and followed by [a-zA-Z0-9]+", "WARNING");
+                ExManip.WriteLog("Formula must start with [a-zA-Z] and followed by [a-zA-Z0-9_]+", "WARNING");
                 return "";
             }
 
@@ -251,7 +251,9 @@ namespace qxlpy
             if (f == "") {
                 return;
             }
+
             ExcelFunc.ClearData(x, y);
+            ExcelFunc.ClearData(x - 1, y);
         }
     }
     // END: public static clase AutoFill

--- a/main.cs
+++ b/main.cs
@@ -163,7 +163,6 @@ namespace qxlpy
                         y + 1, x + ad_row_count, y + 3, x + ad_row_count
                     );
                     // array cells
-                    ExManip.RangeEmpty(array_cells, backtrack);
                     sheet.Columns(x + ad_row_count).ColumnWidth = 12;
                     new_formula += array_cells.Address + comma;
                     // grey out unused cell right to param name
@@ -187,7 +186,6 @@ namespace qxlpy
                         y + 1, x + ad_row_count + 1,
                         y + 3, x + ad_row_count + 2
                     );
-                    ExManip.RangeEmpty(dict_cells, backtrack);
                     sheet.Columns(x + ad_row_count + 1).ColumnWidth = 12;
                     sheet.Columns(x + ad_row_count + 2).ColumnWidth = 12;
                     ad_row_count += 2;

--- a/qxlpy.csproj
+++ b/qxlpy.csproj
@@ -7,6 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <COMReference Include="Microsoft.Office.Interop.Excel">
+      <WrapperTool>tlbimp</WrapperTool>
+      <VersionMinor>9</VersionMinor>
+      <VersionMajor>1</VersionMajor>
+      <Guid>00020813-0000-0000-c000-000000000046</Guid>
+      <Lcid>0</Lcid>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Excel-DNA" Version="1.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- shortcut keys are: ctrl-del to remove output ranges, shift-del to remove formattef UDF, ctrl-shift-del to remove everything :heavy_check_mark:
- disable autocalculate by default :heavy_check_mark:
- bug fix: peg function cell so that in the sheet calculate event, array and dict output will appear under the UDFs :heavy_check_mark:
- added button for function+data removal :heavy_check_mark: